### PR TITLE
Add AI Dev Jobs to ML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@
 | -------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | [ML-Jobs](https://ml-jobs.com/)                                                                          | Find your next Machine Learning Job |
 | [Agentic Engineering Jobs](https://agentic-engineering-jobs.com)                                          | Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post and browse. |
+| [AI Dev Jobs](https://aidevboard.com)                                                                    | Free jobs board aggregating 5,400+ AI/ML/LLM roles from 55+ ATS sources. MCP server + REST API + RSS for agents. |
 
 ## Design
 


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the ML section.

- Free jobs board aggregating 5,400+ AI/ML/LLM roles from 55+ ATS sources
- MCP server at https://aidevboard.com/mcp (JSON-RPC 2.0)
- REST API at /api/v1/jobs (OpenAPI 3.0)
- RSS feed at /feed.xml