### PR TITLE
Add First Look Jobs to ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@
 | [ML-Jobs](https://ml-jobs.com/)                                                                          | Find your next Machine Learning Job |
 | [Agentic Engineering Jobs](https://agentic-engineering-jobs.com)                                          | Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post and browse. |
 | [AI Dev Jobs](https://aidevboard.com)                                                                    | Free jobs board aggregating 5,400+ AI/ML/LLM roles from 55+ ATS sources. MCP server + REST API + RSS for agents. |
+| [First Look Jobs](https://firstlookjobs.com)                                                             | Directory of remote AI training and domain-expert jobs from six referral programs (Mercor, micro1, Turing, Alignerr, Contra, Handshake AI). Advertised pay, weekly hours and country eligibility parsed per listing. |
 
 ## Design
 


### PR DESCRIPTION
Adds First Look Jobs to the ML section.

A directory of remote jobs from six programmes that hire people to train and evaluate AI systems — Mercor, micro1, Turing, Alignerr, Contra and Handshake AI. Every live listing is re-scraped daily.

The ML section currently lists boards for building ML systems; this covers the other side of the same industry — the programmes paying domain experts (law, medicine, finance, engineering) to train and evaluate the models. It parses each programme's published country eligibility per listing, so you can filter to jobs actually open to applicants in your country rather than reading "Remote" and finding out after applying.

No signup, no paywall, no login. Every job links out to the programme's own application.

**Disclosure:** the site is monetised through the programmes' referral schemes and earns a commission if a listed programme hires someone. This is disclosed in the site footer on every page; noting it here since it's the business model.